### PR TITLE
Add ability to enable single port mode for the TFTP server:

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -30,6 +30,18 @@ type Command struct {
 	Log logr.Logger
 	// LogLevel defines the logging level.
 	LogLevel string
+	// EnableTFTPSinglePort is a flag to enable single port mode for the TFTP server.
+	// A standard TFTP server implementation receives requests on port 69 and
+	// allocates a new high port (over 1024) dedicated to that request. In single
+	// port mode, the same port is used for transmit and receive. If the server
+	// is started on port 69, all communication will be done on port 69.
+	// This option is required when running in a container that doesn't bind to the hosts
+	// network because this type of dynamic port allocation is not generally supported.
+	//
+	// This option is specific to github.com/pin/tftp. The pin/tftp library says this option is
+	// experimental and "Enabling this will negatively impact performance". Please take this into
+	// consideration when using this option.
+	EnableTFTPSinglePort bool
 }
 
 // Execute runs the ipxe command.
@@ -101,6 +113,7 @@ func (c *Command) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&c.HTTPAddr, "http-addr", "0.0.0.0:8080", "HTTP server address")
 	f.DurationVar(&c.HTTPTimeout, "http-timeout", time.Second*5, "HTTP server timeout")
 	f.StringVar(&c.LogLevel, "log-level", "info", "Log level")
+	f.BoolVar(&c.EnableTFTPSinglePort, "tftp-single-port", false, "Enable single port mode for TFTP server (needed for container deploys)")
 }
 
 // Validate checks the Command struct for validation errors.

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -27,6 +27,7 @@ func TestCommand_RegisterFlags(t *testing.T) {
 			fs.StringVar(&c.HTTPAddr, "http-addr", "0.0.0.0:8080", "HTTP server address")
 			fs.DurationVar(&c.HTTPTimeout, "http-timeout", time.Second*5, "HTTP server timeout")
 			fs.StringVar(&c.LogLevel, "log-level", "info", "Log level")
+			fs.BoolVar(&c.EnableTFTPSinglePort, "tftp-single-port", false, "Enable single port mode for TFTP server (needed for container deploys)")
 			return fs
 		}()},
 	}

--- a/ipxedust_test.go
+++ b/ipxedust_test.go
@@ -39,8 +39,9 @@ func TestListenAndServe(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := &Server{
-				TFTP: tt.tftp,
-				HTTP: tt.http,
+				TFTP:                 tt.tftp,
+				HTTP:                 tt.http,
+				EnableTFTPSinglePort: true,
 			}
 			ctx, cn := context.WithCancel(context.Background())
 
@@ -49,6 +50,7 @@ func TestListenAndServe(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				err = got.ListenAndServe(ctx)
+
 				wg.Done()
 			}()
 			cn()
@@ -98,7 +100,8 @@ func TestServe(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := &Server{
-				TFTP: tt.tftp,
+				TFTP:                 tt.tftp,
+				EnableTFTPSinglePort: true,
 			}
 			ctx, cn := context.WithCancel(context.Background())
 


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
A standard TFTP server implementation receives requests on port 69 and
allocates a new high port (over 1024) dedicated to that request.
In single-port mode, the same port is used for transmit and receive.
If the server is started on port 69, all communication will be done on port 69.
This option is required when running in a container, that doesn't bind to the hosts
network, because this type of dynamic port allocation is not generally supported.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
