### PR TITLE
Container image building and publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.17"
+          go-version: "1.17.5"
       - name: lint
         run: make lint
       - name: test

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,29 @@
+name: Publish Release
+on:
+  push:
+    tags:
+      - "*"
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.5
+      - name: Login to quay.io
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ ipxe-*.tar.gz
 
 # added by lint-install
 out/
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,77 @@
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - env:
+      - CGO_ENABLED=0
+    flags: -trimpath
+    ldflags: '-s -w -extldflags "-static"'
+    main: ./cmd/
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+      - arm
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      amd64: x86_64
+checksum:
+  name_template: "checksums.txt"
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+dockers:
+  - image_templates:
+      - "quay.io/tinkerbell/ipxedust:{{ .Version }}-amd64"
+    use: buildx
+    dockerfile: Dockerfile.goreleaser
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--platform=linux/amd64"
+  - image_templates:
+      - "quay.io/tinkerbell/ipxedust:{{ .Version }}-arm64"
+    use: buildx
+    goarch: arm64
+    dockerfile: Dockerfile.goreleaser
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--platform=linux/arm64"
+  - image_templates:
+      - "quay.io/tinkerbell/ipxedust:{{ .Version }}-arm"
+    use: buildx
+    goarch: arm
+    goarm: "6"
+    dockerfile: Dockerfile.goreleaser
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--platform=linux/arm/v6"
+docker_manifests:
+  - name_template: quay.io/tinkerbell/ipxedust:{{ .Version }}
+    image_templates:
+      - quay.io/tinkerbell/ipxedust:{{ .Version }}-amd64
+      - quay.io/tinkerbell/ipxedust:{{ .Version }}-arm64
+      - quay.io/tinkerbell/ipxedust:{{ .Version }}-arm

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ RUN CGO_ENABLED=0 make build
 
 FROM scratch
 
-COPY --from=builder /code/bin/ipxedust-linux /ipxedust-linux
+COPY --from=builder /code/bin/ipxedust-linux /ipxedust
 EXPOSE 69/udp
 EXPOSE 8080/tcp
 ENV IPXE_TFTP_SINGLE_PORT=TRUE
 
-ENTRYPOINT ["/ipxedust-linux"]
+ENTRYPOINT ["/ipxedust"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.17.5 as builder
+
+WORKDIR /code
+COPY go.mod go.sum /code/
+RUN go mod download
+
+COPY . /code
+RUN CGO_ENABLED=0 make build
+
+FROM scratch
+
+COPY --from=builder /code/bin/ipxedust-linux /ipxedust-linux
+EXPOSE 69/udp
+EXPOSE 8080/tcp
+ENV IPXE_TFTP_SINGLE_PORT=TRUE
+
+ENTRYPOINT ["/ipxedust-linux"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,8 @@
+FROM scratch
+
+COPY ipxedust /ipxedust
+EXPOSE 69/udp
+EXPOSE 8080/tcp
+ENV IPXE_TFTP_SINGLE_PORT=TRUE
+
+ENTRYPOINT ["/ipxedust"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 OSFLAG:=$(shell go env GOHOSTOS)
-BINARY:=ipxe
+BINARY:=ipxedust
 IPXE_BUILD_SCRIPT:=binary/script/build_ipxe.sh
 IPXE_NIX_SHELL:=binary/script/shell.nix
 
@@ -56,3 +56,7 @@ ifeq (${OSFLAG},linux)
 else
 	@$(MAKE) build-darwin
 endif
+
+.PHONY: build-image
+build-image: ## Build the container image
+	docker build -t ${BINARY}:latest .


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This enables building and publishing container images to quay.io/tinkerbell. GitHub actions and Goreleaser are set up to create and publish container images based on Git tags.

This could potentially be an example repo for how we could handle versioning. See proposal [0002](https://github.com/tinkerbell/proposals/pull/54).

CC: @displague 

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #22 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
