### PR TITLE
Head method

### DIFF
--- a/ihttp/ihttp_test.go
+++ b/ihttp/ihttp_test.go
@@ -127,6 +127,14 @@ func TestHandle(t *testing.T) {
 			},
 		},
 		{
+			name: "success - head request",
+			req:  req{method: "HEAD", url: "/30:23:03:73:a5:a7/snp.efi-00-23b1e307bb35484f535a1f772c06910e-d887dc3912240434-01"},
+			want: &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       nil,
+			},
+		},
+		{
 			name: "fail with bad traceparent",
 			req:  req{method: "GET", url: "/30:23:03:73:a5:a7/snp.efi-00-00000000000000000000000000000000-d887dc3912240434-01"},
 			want: &http.Response{

--- a/ipxedust.go
+++ b/ipxedust.go
@@ -86,7 +86,7 @@ func (c *Server) ListenAndServe(ctx context.Context) error {
 
 	<-ctx.Done()
 	err = g.Wait()
-	c.Log.Info("shutting down")
+	c.Log.Info("shutting down iPXE servers")
 
 	return err
 }
@@ -124,7 +124,7 @@ func (c *Server) Serve(ctx context.Context, tcpConn net.Listener, udpConn net.Pa
 
 	<-ctx.Done()
 	err = g.Wait()
-	c.Log.Info("shutting down")
+	c.Log.Info("shutting down iPXE servers")
 
 	return err
 }
@@ -138,7 +138,7 @@ func (c *Server) listenAndServeHTTP(ctx context.Context) error {
 		BaseContext: func(net.Listener) context.Context { return ctx },
 		ReadTimeout: c.HTTP.Timeout,
 	}
-	c.Log.Info("serving HTTP", "addr", c.HTTP.Addr.String(), "timeout", c.HTTP.Timeout)
+	c.Log.Info("serving iPXE binaries via HTTP", "addr", c.HTTP.Addr.String(), "timeout", c.HTTP.Timeout)
 	g, ctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
 		return ihttp.ListenAndServe(ctx, c.HTTP.Addr, hs)
@@ -168,7 +168,7 @@ func (c *Server) serveHTTP(ctx context.Context, l net.Listener) error {
 		BaseContext: func(net.Listener) context.Context { return ctx },
 		ReadTimeout: c.HTTP.Timeout,
 	}
-	c.Log.Info("serving HTTP", "addr", l.Addr().String(), "timeout", c.HTTP.Timeout)
+	c.Log.Info("serving iPXE binaries via HTTP", "addr", l.Addr().String(), "timeout", c.HTTP.Timeout)
 	g, ctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
 		return ihttp.Serve(ctx, l, hs)
@@ -202,7 +202,7 @@ func (c *Server) listenAndServeTFTP(ctx context.Context) error {
 	if c.EnableTFTPSinglePort {
 		ts.EnableSinglePort()
 	}
-	c.Log.Info("serving TFTP", "addr", c.TFTP.Addr, "timeout", c.TFTP.Timeout, "singlePortEnabled", c.EnableTFTPSinglePort)
+	c.Log.Info("serving iPXE binaries via TFTP", "addr", c.TFTP.Addr, "timeout", c.TFTP.Timeout, "singlePortEnabled", c.EnableTFTPSinglePort)
 	g, ctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
 		return itftp.Serve(ctx, conn, ts)
@@ -243,7 +243,7 @@ func (c *Server) serveTFTP(ctx context.Context, conn net.PacketConn) error {
 	if c.EnableTFTPSinglePort {
 		ts.EnableSinglePort()
 	}
-	c.Log.Info("serving TFTP", "addr", conn.LocalAddr().String(), "timeout", c.TFTP.Timeout, "singlePortEnabled", c.EnableTFTPSinglePort)
+	c.Log.Info("serving iPXE binaries via TFTP", "addr", conn.LocalAddr().String(), "timeout", c.TFTP.Timeout, "singlePortEnabled", c.EnableTFTPSinglePort)
 	g, ctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
 		return itftp.Serve(ctx, conn, ts)


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
HTTPClient network boot clients use the HEAD method to get the size before downloading.

https://github.com/tinkerbell/boots/pull/216/files#diff-a8783392d81a537e4fb749c1b3e44b23ad376a7ee72440e0cefe1597ddd28acfR24-R27

https://github.com/tinkerbell/boots/pull/229#issuecomment-1011467759

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
