### PR TITLE
include the POWEROFF_CMD in ipxe builds

### DIFF
--- a/binary/script/ipxe-customizations/common.h
+++ b/binary/script/ipxe-customizations/common.h
@@ -6,6 +6,7 @@
 #define NTP_CMD               /* NTP commands */
 #define NVO_CMD               /* Non-volatile option storage commands */
 #define PARAM_CMD             /* params and param commands, for POSTing to tink */
+#define POWEROFF_CMD          /* Power off command */
 #define REBOOT_CMD            /* Reboot command */
 #define SANBOOT_PROTO_HTTP    /* HTTP SAN protocol */
 #define VLAN_CMD              /* VLAN commands */


### PR DESCRIPTION


## Description

This PR allows devices to poweroff during the IPXE stage.  

## Why is this needed

In Equinix Metal settings, this allows for scheduled customizations, say to userdata, based on device details that can not be known until the on-demand device is selected and provisioned.

In Tinkerbell settings, this allows for IPXE scripts to perform tasks and then conserve power until awoken by the BMC or user.

Adding this capability should be harmless since the capability is already present at later (and depending on the environment, earlier) stages.
Devices have the capability to poweroff at anytime from an IPXE chained boot. Devices can even reboot from within IPXE with the options provided today.

Related request: https://feedback.equinixmetal.com/operating-systems/p/enable-the-poweroff-command-in-the-ipxe-image

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
