### PR TITLE
Enable the iPXE ping command

### DIFF
--- a/binary/script/ipxe-customizations/common.h
+++ b/binary/script/ipxe-customizations/common.h
@@ -6,6 +6,7 @@
 #define NTP_CMD               /* NTP commands */
 #define NVO_CMD               /* Non-volatile option storage commands */
 #define PARAM_CMD             /* params and param commands, for POSTing to tink */
+#define PING_CMD              /* Ping command */
 #define POWEROFF_CMD          /* Power off command */
 #define REBOOT_CMD            /* Reboot command */
 #define SANBOOT_PROTO_HTTP    /* HTTP SAN protocol */


### PR DESCRIPTION
## Description

Enable the built in ping command inside of the iPXE environment.
Port of tinkerbell/boots#181

## Why is this needed

Operators debugging network issues sometimes find it useful to be able to issue ping commands from the iPXE environment to verify network configuration.

If this was intentionally not brought over from boots, feel free to close this without merging.

## How Has This Been Tested?

This has not been tested yet. Do we want to bring over some of the testing that I implemented for the ipxe build in boots?