### PR TITLE
Offer the operator a chance to drop to iPXE shell

### DIFF
--- a/binary/script/embed.ipxe
+++ b/binary/script/embed.ipxe
@@ -3,4 +3,7 @@
 set user-class Tinkerbell
 echo Welcome to Neverland!
 
+# Allow the operator to drop to a shell
+prompt --key 0x02 --timeout 2000 Press Ctrl-B for the iPXE command line... && shell ||
+
 autoboot


### PR DESCRIPTION
## Description

Add a 2 second prompt for an operator to drop to iPXE shell for debugging to the embedded ipxe script
Reference: https://ipxe.org/cmd/prompt

## Why is this needed

Fixes: #33

## How Has This Been Tested?

- [x] Test in a sandbox

## How are existing users impacted? What migration steps/scripts do we need?

N/A

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade