### PR TITLE
disable ocsp check

### DIFF
--- a/binary/script/build_and_pr.sh
+++ b/binary/script/build_and_pr.sh
@@ -7,6 +7,7 @@ tracked_files=(
     "./script/ipxe-customizations/console.h"
     "./script/ipxe-customizations/isa.h"
     "./script/ipxe-customizations/colour.h"
+    "./script/ipxe-customizations/crypto.h"
     "./script/ipxe-customizations/general.efi.h"
     "./script/ipxe-customizations/general.undionly.h"
     "./script/ipxe-customizations/common.h"

--- a/binary/script/build_ipxe.sh
+++ b/binary/script/build_ipxe.sh
@@ -74,6 +74,7 @@ function copy_common_files() {
     cp -a binary/script/ipxe-customizations/colour.h "${ipxe_dir}"/src/config/local/
     cp -a binary/script/ipxe-customizations/common.h "${ipxe_dir}"/src/config/local/
     cp -a binary/script/ipxe-customizations/console.h "${ipxe_dir}"/src/config/local/
+    cp -a binary/script/ipxe-customizations/crypto.h "${ipxe_dir}"/src/config/local/
 }
 
 # copy_custom_files will copy in any custom header files based on a requested ipxe binary.

--- a/binary/script/ipxe-customizations/crypto.h
+++ b/binary/script/ipxe-customizations/crypto.h
@@ -1,0 +1,1 @@
+#undef OCSP_CHECK


### PR DESCRIPTION
## Description

disabling ocsp_check to match original tinkerbell/boots configuration
https://github.com/tinkerbell/boots/blob/bd87a7a7a95d25077f183c298c003335fc67e031/ipxe/ipxe/build.sh#L14

This is also disabled in other widely used ipxe builds such as
netboot.xyz
https://github.com/netbootxyz/netboot.xyz/blob/d8a5c3e8e88772ea3d74175faa012cf575afe707/roles/netbootxyz/files/ipxe/local/crypto.h

## Why is this needed

With this enabled, ipxe has issues validating tls within a private
environment that has no route to the internet to do ocsp checks.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
