### PR TITLE
Make it correctly

### DIFF
--- a/.github/workflows/ipxe.yaml
+++ b/.github/workflows/ipxe.yaml
@@ -17,4 +17,4 @@ jobs:
       - name: Build iPXE
         env:
           GITHUB_TOKEN: ${{ secrets.Token }}
-        run: (cd binary/; ./script/build_and_pr.sh)
+        run: (cd binary/; MAKEFLAGS=-j$(nproc) ./script/build_and_pr.sh)

--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,13 @@ $(ipxe_readme): binary/script/ipxe.commit
 	touch "$@"
 
 binary/ipxe.efi: $(ipxe_readme) ## build ipxe.efi
-	${IPXE_BUILD_SCRIPT} bin-x86_64-efi/ipxe.efi "$(ipxe_sha_or_tag)" $(ipxe_build_in_docker) $@ "${IPXE_NIX_SHELL}"
+	+${IPXE_BUILD_SCRIPT} bin-x86_64-efi/ipxe.efi "$(ipxe_sha_or_tag)" $(ipxe_build_in_docker) $@ "${IPXE_NIX_SHELL}"
 
 binary/undionly.kpxe: $(ipxe_readme) ## build undionly.kpxe
-	${IPXE_BUILD_SCRIPT} bin/undionly.kpxe "$(ipxe_sha_or_tag)" $(ipxe_build_in_docker) $@ "${IPXE_NIX_SHELL}"
+	+${IPXE_BUILD_SCRIPT} bin/undionly.kpxe "$(ipxe_sha_or_tag)" $(ipxe_build_in_docker) $@ "${IPXE_NIX_SHELL}"
 
 binary/snp.efi: $(ipxe_readme) ## build snp.efi
-	${IPXE_BUILD_SCRIPT} bin-arm64-efi/snp.efi "$(ipxe_sha_or_tag)" $(ipxe_build_in_docker) $@  "${IPXE_NIX_SHELL}" "CROSS_COMPILE=aarch64-unknown-linux-gnu-"
+	+${IPXE_BUILD_SCRIPT} bin-arm64-efi/snp.efi "$(ipxe_sha_or_tag)" $(ipxe_build_in_docker) $@  "${IPXE_NIX_SHELL}" "CROSS_COMPILE=aarch64-unknown-linux-gnu-"
 
 .PHONY: binary/clean
 binary/clean: ## clean ipxe binaries, upstream ipxe source code directory, and ipxe source tarball

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-OSFLAG:=$(shell go env GOHOSTOS)
-BINARY:=ipxe
-IPXE_BUILD_SCRIPT:=binary/script/build_ipxe.sh
-IPXE_NIX_SHELL:=binary/script/shell.nix
+OSFLAG := $(shell go env GOHOSTOS)
+BINARY := ipxe
+IPXE_BUILD_SCRIPT := binary/script/build_ipxe.sh
+IPXE_NIX_SHELL := binary/script/shell.nix
 
 help: ## show this help message
 	@grep -E '^[a-zA-Z_-]+.*:.*?## .*$$' Makefile | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[32m%-30s\033[0m %s\n", $$1, $$2}'

--- a/binary/script/build_ipxe.sh
+++ b/binary/script/build_ipxe.sh
@@ -4,32 +4,6 @@
 
 set -eux
 
-# download_ipxe_repo will download a source archive from github.
-function download_ipxe_repo() {
-    local sha_or_tag="$1"
-    if [ ! -f "ipxe-${sha_or_tag}.tar.gz" ]; then
-        echo "downloading"
-        curl -fLo ipxe-"${sha_or_tag}".tar.gz https://github.com/ipxe/ipxe/archive/"${sha_or_tag}".tar.gz
-    else
-        echo "already downloaded"
-    fi
-    
-}
-
-# extract_ipxe_repo will extract a tarball.
-function extract_ipxe_repo() {
-    local archive_name="$1"
-    local archive_dir="$2"
-
-    if [ ! -d "$archive_dir" ]; then
-        echo "extracting"
-        mkdir -p "${archive_dir}"
-        tar -xzf "${archive_name}" -C "${archive_dir}" --strip-components 1
-    else
-        echo "already extracted"
-    fi
-}
-
 # build_ipxe will run the make target in the upstream ipxe source
 # that will build an ipxe binary.
 function build_ipxe() {
@@ -174,9 +148,8 @@ function main() {
         hasDocker
     fi
 
-    download_ipxe_repo "${ipxe_sha_or_tag}"
-    extract_ipxe_repo "ipxe-${ipxe_sha_or_tag}.tar.gz" "upstream-${ipxe_sha_or_tag}"
     mv_embed_into_build "${embed_path}" "upstream-${ipxe_sha_or_tag}"
+
     customize "upstream-${ipxe_sha_or_tag}" "${bin_path}"
     build_ipxe "upstream-${ipxe_sha_or_tag}" "${bin_path}" "${ipxe_build_in_docker}" "${env_opts}" "embed.ipxe" "${nix_shell}"
     cp -a "upstream-${ipxe_sha_or_tag}/src/${bin_path}" "${final_path}"

--- a/binary/script/build_ipxe.sh
+++ b/binary/script/build_ipxe.sh
@@ -131,20 +131,13 @@ function setup_build_dir() {
 
 # main function orchestrating a full ipxe compile.
 function main() {
-    local bin_path
-    bin_path=$(echo "${1}" | xargs)
-    local ipxe_sha_or_tag
-    ipxe_sha_or_tag=$(echo "${2}" | xargs)
-    local ipxe_build_in_docker
-    ipxe_build_in_docker=$(echo "${3}" | xargs)
-    local final_path
-    final_path=$(echo "${4}" | xargs)
-    local nix_shell
-    nix_shell=$(echo "${5}" | xargs)
-    local env_opts
-    env_opts=$(echo "${6}" | xargs)
-    local embed_path
-    embed_path=$(echo "${7}" | xargs)
+    local bin_path=${1}
+    local ipxe_sha_or_tag=${2}
+    local ipxe_build_in_docker=${3}
+    local final_path=${4}
+    local nix_shell=${5}
+    local env_opts=${6}
+    local embed_path=${7}
 
     # check for prerequisites
     hasType
@@ -167,4 +160,4 @@ function main() {
     cp -a "${build_dir}/src/${bin_path}" "${final_path}"
 }
 
-main "$1" "$2" "$3" "$4" "$5" "${6:-''}" "${7:-binary/script/embed.ipxe}"
+main "$1" "$2" "$3" "$4" "$5" "${6:-}" "${7:-binary/script/embed.ipxe}"

--- a/binary/script/fetch_and_extract_ipxe.sh
+++ b/binary/script/fetch_and_extract_ipxe.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# download_ipxe_repo will download a source archive from github.
+function download_ipxe_repo() {
+	local sha_or_tag="$1"
+	local archive_name="$2"
+	if [ ! -f "${archive_name}" ]; then
+		echo "downloading"
+		curl -fLo "${archive_name}.tmp" https://github.com/ipxe/ipxe/archive/"${sha_or_tag}".tar.gz
+		mv "${archive_name}.tmp" "${archive_name}"
+	else
+		echo "already downloaded"
+	fi
+
+}
+
+# extract_ipxe_repo will extract a tarball.
+function extract_ipxe_repo() {
+	local archive_name="$1"
+	local archive_dir="$2"
+
+	if [ ! -d "$archive_dir" ]; then
+		echo "extracting"
+		mkdir -p "${archive_dir}.tmp"
+		tar -xzf "${archive_name}" -C "${archive_dir}.tmp" --strip-components 1
+		mv "${archive_dir}.tmp" "${archive_dir}"
+	else
+		echo "already extracted"
+	fi
+}
+
+ipxe_sha_or_tag=$1
+archive_name=ipxe-${ipxe_sha_or_tag}.tar.gz
+download_ipxe_repo "${ipxe_sha_or_tag}" "${archive_name}"
+extract_ipxe_repo "${archive_name}" "upstream-${ipxe_sha_or_tag}"

--- a/binary/script/shell.nix
+++ b/binary/script/shell.nix
@@ -1,27 +1,31 @@
-let _pkgs = import <nixpkgs> { };
-in { pkgs ? import (_pkgs.fetchFromGitHub {
-  owner = "NixOS";
-  repo = "nixpkgs";
-  #branch@date: nixpkgs@2020-11-24
-  rev = "6625284c397b44bc9518a5a1567c1b5aae455c08";
-  sha256 = "1w0czzv53sg35gp7sr506facbmzd33jm34p6cg23fb9kz5rf5c89";
-}) { } }:
-
-with pkgs;
-
 let
-
-in mkShell {
-  buildInputs = [
-    curl
-    expect
-    gcc
-    git
-    gnumake
-    go
-    perl
-    xz
-  ] ++ lib.optionals stdenv.isLinux
-    [ pkgsCross.aarch64-multiplatform.buildPackages.gcc ];
-}
-
+  _pkgs = import <nixpkgs> {};
+in
+  {
+    pkgs ?
+      import (_pkgs.fetchFromGitHub {
+        owner = "NixOS";
+        repo = "nixpkgs";
+        #branch@date: nixpkgs@2020-11-24
+        rev = "6625284c397b44bc9518a5a1567c1b5aae455c08";
+        sha256 = "1w0czzv53sg35gp7sr506facbmzd33jm34p6cg23fb9kz5rf5c89";
+      }) {},
+  }:
+    with pkgs; let
+    in
+      mkShell {
+        buildInputs =
+          [
+            curl
+            expect
+            gcc
+            git
+            gnumake
+            go
+            perl
+            xz
+          ]
+          ++ lib.optionals stdenv.isLinux [
+            pkgsCross.aarch64-multiplatform.buildPackages.gcc
+          ];
+      }

--- a/binary/script/shell.nix
+++ b/binary/script/shell.nix
@@ -6,26 +6,27 @@ in
       import (_pkgs.fetchFromGitHub {
         owner = "NixOS";
         repo = "nixpkgs";
-        #branch@date: nixpkgs@2020-11-24
-        rev = "6625284c397b44bc9518a5a1567c1b5aae455c08";
-        sha256 = "1w0czzv53sg35gp7sr506facbmzd33jm34p6cg23fb9kz5rf5c89";
+        #branch@date: nixos-21.11@2022-08-02
+        rev = "eabc38219184cc3e04a974fe31857d8e0eac098d";
+        sha256 = "04ffwp2gzq0hhz7siskw6qh9ys8ragp7285vi1zh8xjksxn1msc5";
       }) {},
   }:
     with pkgs; let
     in
-      mkShell {
+      mkShellNoCC {
         buildInputs =
           [
             curl
             expect
-            gcc
+            gcc9
             git
             gnumake
+            gnused
             go
             perl
             xz
           ]
           ++ lib.optionals stdenv.isLinux [
-            pkgsCross.aarch64-multiplatform.buildPackages.gcc
+            pkgsCross.aarch64-multiplatform.buildPackages.gcc9
           ];
       }


### PR DESCRIPTION
## Description

Fixes to Makefile/build system so parallel builds work better.

## Why is this needed

Parallel builds were previously racy and/or wasting time and bandwidth. We could have either been fetching ipxe source files multiple times (potentially once for each target) or the first build_ipxe.sh to run will start to fetch the tarball and subsequent ones could see the incomplete file and begin to try and extract it with all sorts of fun ensuing.

## How Has This Been Tested?

I've forced fetching/rebuilding of the ipxe files multiple times with no problems. I've also interrupted both curl and tar and verified that next invocations do the right thing.

## How are existing users impacted? What migration steps/scripts do we need?

More reliable builds.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
