### PR TITLE
Plumb cli flag for tftp-single-port through to config:

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -101,7 +101,8 @@ func (c *Command) Run(ctx context.Context) error {
 			Addr:    hAddr,
 			Timeout: c.HTTPTimeout,
 		},
-		Log: c.Log,
+		Log:                  c.Log,
+		EnableTFTPSinglePort: c.EnableTFTPSinglePort,
 	}
 	return srv.ListenAndServe(ctx)
 }


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
The cli flag wasn't being honored.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
