### PR TITLE
Add vlan support to embedded script:

### DIFF
--- a/binary/script/embed.ipxe
+++ b/binary/script/embed.ipxe
@@ -6,4 +6,21 @@ echo Welcome to Neverland!
 # Allow the operator to drop to a shell
 prompt --key 0x02 --timeout 2000 Press Ctrl-B for the iPXE command line... && shell ||
 
+set vlan-id ${43.116:string}
+isset ${vlan-id} && goto boot-with-vlan ||
+
+:autoboot
 autoboot
+
+:boot-with-vlan
+set idx:int32 0
+# Find the first interface that is configured
+:loop isset ${net${idx}/mac} && goto loop_done ||
+  inc idx && goto loop
+:loop_done
+
+vcreate --tag ${vlan-id} net${idx} || goto autoboot
+echo Created VLAN network interface net${idx}-${vlan-id}
+echo Booting from net${idx}-${vlan-id}...
+
+autoboot net${idx}-${vlan-id}

--- a/binary/script/embed.ipxe
+++ b/binary/script/embed.ipxe
@@ -6,6 +6,8 @@ echo Welcome to Neverland!
 # Allow the operator to drop to a shell
 prompt --key 0x02 --timeout 2000 Press Ctrl-B for the iPXE command line... && shell ||
 
+# This is possible because the DHCP options from the original vendor PXE DHCP request
+# are available to chainloaded iPXE binaries. See https://github.com/ipxe/ipxe/issues/188
 set vlan-id ${43.116:string}
 isset ${vlan-id} && goto boot-with-vlan ||
 


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This allows creating an interface with a vlan tag based off of DHCP option 43, suboption 116. This will not change the existing behavior. The vlan interface is only created if DHCP option 43.116 is set. This PR is the start of the implementation of [proposal 28](https://github.com/tinkerbell/proposals/pull/60).

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have manually test this.


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->
No impact.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
