### PR TITLE
Enable the iPXE certificate commands

### DIFF
--- a/binary/script/ipxe-customizations/common.h
+++ b/binary/script/ipxe-customizations/common.h
@@ -1,3 +1,4 @@
+#define CERT_CMD              /* Certificate management commands */
 #define DIGEST_CMD            /* Image crypto digest commands */
 #define DOWNLOAD_PROTO_HTTPS  /* Secure Hypertext Transfer Protocol */
 #define IMAGE_TRUST_CMD       /* Image trust management commands */


### PR DESCRIPTION
## Description

Enable the iPXE certificate management commands
See https://ipxe.org/buildcfg/cert_cmd

Enables
- [certstat](https://ipxe.org/cmd/certstat) 
- [certstore](https://ipxe.org/cmd/certstore)
- [certfree](https://ipxe.org/cmd/certfree)

## Why is this needed

Enables use of commands to debug TLS certificate issues.

## How Has This Been Tested?

I did local builds and used the resulting binaries.

## How are existing users impacted? What migration steps/scripts do we need?

Consumers of ipxedust need to update to the latest version after fresh binaries are built and merged.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
