### PR TITLE
Add support for patching embedded ipxe scripts

### DIFF
--- a/binary/binary.go
+++ b/binary/binary.go
@@ -36,6 +36,9 @@ var Files = map[string][]byte{
 
 var ErrPatchTooLong = errors.New("patch string is too long")
 
+// Replace the magic string in the content with the patch. Returns the original content
+// when the patch is empty or the magic string is not found, and returns an error when
+// the patch is too long.
 func Patch(content, patch []byte) ([]byte, error) {
 	// Noop when no patch is passed.
 	if len(patch) == 0 {

--- a/binary/binary.go
+++ b/binary/binary.go
@@ -25,6 +25,8 @@ var SNP []byte
 var magicString = []byte(`#a8b7e61f1075c37a793f2f92cee89f7bba00c4a8d7842ce3d40b5889032d8881
 #ddd16a4fc4926ecefdfb6941e33c44ed3647133638f5e84021ea44d3152e7f97`)
 
+var magicStringPadding = bytes.Repeat([]byte{' '}, len(magicString))
+
 // Files is the mapping to the embedded iPXE binaries.
 var Files = map[string][]byte{
 	"undionly.kpxe": Undionly,
@@ -46,7 +48,7 @@ func Patch(content, patch []byte) ([]byte, error) {
 		return content, nil
 	}
 
-	if len(patch) >= len(magicString) {
+	if len(patch) > len(magicString) {
 		return nil, ErrPatchTooLong
 	}
 
@@ -54,8 +56,8 @@ func Patch(content, patch []byte) ([]byte, error) {
 	// the underlying array.
 	dup := make([]byte, len(content))
 	copy(dup, content)
+	copy(dup[i:], magicStringPadding)
 	copy(dup[i:], patch)
-	dup[i+len(patch)] = '#'
 
 	return dup, nil
 }

--- a/binary/binary.go
+++ b/binary/binary.go
@@ -5,7 +5,7 @@ package binary
 import (
 	"bytes"
 	_ "embed"
-	"fmt"
+	"errors"
 )
 
 // IpxeEFI is the UEFI iPXE binary for x86 architectures.
@@ -32,6 +32,8 @@ var Files = map[string][]byte{
 	"snp.efi":       SNP,
 }
 
+var ErrPatchTooLong = errors.New("patch string is too long")
+
 func Patch(content, patch []byte) ([]byte, error) {
 	// Noop when no patch is passed.
 	if len(patch) == 0 {
@@ -45,7 +47,7 @@ func Patch(content, patch []byte) ([]byte, error) {
 	}
 
 	if len(patch) >= len(magicString) {
-		return nil, fmt.Errorf("patch string is too long")
+		return nil, ErrPatchTooLong
 	}
 
 	// Duplicate the content before applying the patch so we don't overwrite

--- a/binary/binary.go
+++ b/binary/binary.go
@@ -2,7 +2,11 @@
 package binary
 
 // embed lib does the work of embedding the on disk iPXE binaries.
-import _ "embed"
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+)
 
 // IpxeEFI is the UEFI iPXE binary for x86 architectures.
 //go:embed ipxe.efi
@@ -16,9 +20,40 @@ var Undionly []byte
 //go:embed snp.efi
 var SNP []byte
 
+// MagicString is included in each iPXE binary within the embedded script. It
+// can be overwritten to change the behavior at startup.
+var magicString = []byte(`#a8b7e61f1075c37a793f2f92cee89f7bba00c4a8d7842ce3d40b5889032d8881
+#ddd16a4fc4926ecefdfb6941e33c44ed3647133638f5e84021ea44d3152e7f97`)
+
 // Files is the mapping to the embedded iPXE binaries.
 var Files = map[string][]byte{
 	"undionly.kpxe": Undionly,
 	"ipxe.efi":      IpxeEFI,
 	"snp.efi":       SNP,
+}
+
+func Patch(content, patch []byte) ([]byte, error) {
+	// Noop when no patch is passed.
+	if len(patch) == 0 {
+		return content, nil
+	}
+
+	// Also noop when there's no magic patch string available in the content.
+	i := bytes.Index(content, magicString)
+	if i == -1 {
+		return content, nil
+	}
+
+	if len(patch) >= len(magicString) {
+		return nil, fmt.Errorf("patch string is too long")
+	}
+
+	// Duplicate the content before applying the patch so we don't overwrite
+	// the underlying array.
+	dup := make([]byte, len(content))
+	copy(dup, content)
+	copy(dup[i:], patch)
+	dup[i+len(patch)] = '#'
+
+	return dup, nil
 }

--- a/binary/binary_test.go
+++ b/binary/binary_test.go
@@ -56,7 +56,7 @@ func TestPatch(t *testing.T) {
 			name:    "patch",
 			content: []byte("foo\n"+string(magicString)),
 			patch:   []byte("baz"),
-			want:    []byte("foo\nbaz#"+string(magicString[4:])),
+			want:    []byte("foo\nbaz"+string(magicStringPadding[3:])),
 		},
 	}
 	for _, tt := range tests {

--- a/binary/binary_test.go
+++ b/binary/binary_test.go
@@ -1,0 +1,21 @@
+package binary
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestBinariesContainMagicString(t *testing.T) {
+	for file, data := range Files {
+		if file == "undionly.kpxe" {
+			continue // undionly.kpxe does not support binary patching
+		}
+
+		count := bytes.Count(data, MagicString)
+		if count == 0 {
+			t.Errorf("%s binary does not contain magic string", file)
+		} else if count > 1 {
+			t.Errorf("%s binary contains magic string more than once", file)
+		}
+	}
+}

--- a/binary/binary_test.go
+++ b/binary/binary_test.go
@@ -19,3 +19,56 @@ func TestBinariesContainMagicString(t *testing.T) {
 		}
 	}
 }
+
+func TestPatch(t *testing.T) {
+	tests := []struct {
+		name    string
+		content []byte
+		patch   []byte
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name:    "no patch",
+			content: []byte("foo\n"+string(magicString)),
+			patch:   []byte(""),
+			want:    []byte("foo\n"+string(magicString)),
+		},
+		{
+			name:    "nil patch",
+			content: []byte("foo"),
+			patch:   nil,
+			want:    []byte("foo"),
+		},
+		{
+			name:    "no magic string",
+			content: []byte("foo"),
+			patch:   []byte("bar"),
+			want:    []byte("foo"),
+		},
+		{
+			name:    "patch too long",
+			content: []byte("foo\n"+string(magicString)),
+			patch:   make([]byte, 1024),
+			wantErr: true,
+		},
+		{
+			name:    "patch",
+			content: []byte("foo\n"+string(magicString)),
+			patch:   []byte("baz"),
+			want:    []byte("foo\nbaz#"+string(magicString[4:])),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Patch(tt.content, tt.patch)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Patch() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !bytes.Equal(got, tt.want) {
+				t.Errorf("Patch() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/binary/binary_test.go
+++ b/binary/binary_test.go
@@ -11,7 +11,7 @@ func TestBinariesContainMagicString(t *testing.T) {
 			continue // undionly.kpxe does not support binary patching
 		}
 
-		count := bytes.Count(data, MagicString)
+		count := bytes.Count(data, magicString)
 		if count == 0 {
 			t.Errorf("%s binary does not contain magic string", file)
 		} else if count > 1 {

--- a/ihttp/ihttp.go
+++ b/ihttp/ihttp.go
@@ -24,7 +24,8 @@ import (
 
 // Handler is the struct that implements the http.Handler interface.
 type Handler struct {
-	Log logr.Logger
+	Log   logr.Logger
+	Patch []byte
 }
 
 // ListenAndServe is a patterned after http.ListenAndServe.
@@ -97,6 +98,14 @@ func (s Handler) Handle(w http.ResponseWriter, req *http.Request) {
 		http.NotFound(w, req)
 		span.SetStatus(codes.Error, "requested file not found")
 
+		return
+	}
+
+	file, err = binary.Patch(file, s.Patch)
+	if err != nil {
+		log.Error(err, "error patching file")
+		w.WriteHeader(http.StatusInternalServerError)
+		span.SetStatus(codes.Error, err.Error())
 		return
 	}
 

--- a/ihttp/ihttp_test.go
+++ b/ihttp/ihttp_test.go
@@ -100,6 +100,8 @@ func TestListenAndServeHTTP(t *testing.T) {
 }
 
 func TestHandle(t *testing.T) {
+	patched_binary, _ := binary.Patch(binary.Files["snp.efi"], []byte("echo 'hello world'"))
+
 	type req struct {
 		method string
 		url    string
@@ -109,6 +111,7 @@ func TestHandle(t *testing.T) {
 		name      string
 		req       req
 		want      *http.Response
+		patch     []byte
 		failWrite bool
 	}{
 		{
@@ -149,6 +152,23 @@ func TestHandle(t *testing.T) {
 				StatusCode: http.StatusNotFound,
 			},
 		},
+		{
+			name: "patch",
+			req: req{method: "GET", url: "/30:23:03:73:a5:a7/snp.efi-00-23b1e307bb35484f535a1f772c06910e-d887dc3912240434-01"},
+			want: &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewBuffer(patched_binary)),
+			},
+			patch: []byte("echo 'hello world'"),
+		},
+		{
+			name: "bad patch",
+			req: req{method: "GET", url: "/30:23:03:73:a5:a7/snp.efi-00-23b1e307bb35484f535a1f772c06910e-d887dc3912240434-01"},
+			want: &http.Response{
+				StatusCode: http.StatusInternalServerError,
+			},
+			patch: make([]byte, 131),
+		},
 	}
 
 	for _, tt := range tests {
@@ -158,12 +178,12 @@ func TestHandle(t *testing.T) {
 			var resp *http.Response
 			if tt.failWrite {
 				w := newFakeResponse()
-				h := Handler{Log: logger}
+				h := Handler{Log: logger, Patch: tt.patch}
 				h.Handle(w, req)
 				resp = w.Result()
 			} else {
 				w := httptest.NewRecorder()
-				h := Handler{Log: logger}
+				h := Handler{Log: logger, Patch: tt.patch}
 				h.Handle(w, req)
 				resp = w.Result()
 			}

--- a/ihttp/ihttp_test.go
+++ b/ihttp/ihttp_test.go
@@ -167,7 +167,7 @@ func TestHandle(t *testing.T) {
 			want: &http.Response{
 				StatusCode: http.StatusInternalServerError,
 			},
-			patch: make([]byte, 131),
+			patch: make([]byte, 132),
 		},
 	}
 

--- a/itftp/itftp.go
+++ b/itftp/itftp.go
@@ -25,6 +25,7 @@ import (
 // Handler is the struct that implements the TFTP read and write function handlers.
 type Handler struct {
 	Log logr.Logger
+	Patch []byte
 }
 
 // ListenAndServe sets up the listener on the given address and serves TFTP requests.
@@ -91,6 +92,14 @@ func (t Handler) HandleRead(filename string, rf io.ReaderFrom) error {
 		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
+
+	content, err = binary.Patch(content, t.Patch)
+	if err != nil {
+		log.Error(err, "failed to patch binary")
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+
 	ct := bytes.NewReader(content)
 	b, err := rf.ReadFrom(ct)
 	if err != nil {

--- a/itftp/itftp_test.go
+++ b/itftp/itftp_test.go
@@ -97,6 +97,7 @@ func TestHandleRead(t *testing.T) {
 	tests := []struct {
 		name     string
 		fileName string
+		patch    []byte
 		want     []byte
 		wantErr  error
 	}{
@@ -125,11 +126,17 @@ func TestHandleRead(t *testing.T) {
 			fileName: "snp.efi",
 			wantErr:  net.ErrClosed,
 		},
+		{
+			name:     "failure - bad patch",
+			fileName: "snp.efi",
+			patch:    make([]byte, 500),
+			wantErr:  binary.ErrPatchTooLong,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ht := &Handler{Log: logr.Discard()}
+			ht := &Handler{Log: logr.Discard(), Patch: tt.patch}
 			rf := &fakeReaderFrom{
 				addr:    net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 9999},
 				content: make([]byte, len(tt.want)),


### PR DESCRIPTION
## Description

This PR enables modifying the embedded ipxe script within served binaries at runtime.

It may seem very brittle to assume that the raw bytes of the script will directly end up in the final binary, but in practice this seems to work quite well and is vastly simpler than trying to unpack and repack the binaries.

## Why is this needed

This enables flexibility if the default boot script does not match user requirements, or if users want to pass additional information that will not be known at runtime.

We use this to add `dhcp && chain http://<ip-address>/auto.ipxe || shell` to the start of the script which prevents ipxe from having to query the network to find where it should chain boot from.

## How Has This Been Tested?

I confirmed that I was able to boot a machine with an ipxe script that had been patched using this method.

## How are existing users impacted? What migration steps/scripts do we need?

Default behavior remains unchanged.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [ ] provided instructions on how to upgrade
