### PR TITLE
Use http.ServeContent

### DIFF
--- a/ihttp/ihttp.go
+++ b/ihttp/ihttp.go
@@ -2,6 +2,7 @@
 package ihttp
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net"
@@ -11,6 +12,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/tinkerbell/ipxedust/binary"
@@ -97,17 +99,10 @@ func (s Handler) Handle(w http.ResponseWriter, req *http.Request) {
 
 		return
 	}
-	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(file)))
-	if req.Method == http.MethodGet {
-		b, err := w.Write(file)
-		if err != nil {
-			log.Error(err, "error serving file")
-			w.WriteHeader(http.StatusInternalServerError)
-			span.SetStatus(codes.Error, err.Error())
 
-			return
-		}
-		log.Info("file served", "bytesSent", b, "fileSize", len(file))
+	http.ServeContent(w, req, filename, time.Now(), bytes.NewReader(file))
+	if req.Method == http.MethodGet {
+		log.Info("file served", "name", filename, "fileSize", len(file))
 	} else if req.Method == http.MethodHead {
 		log.Info("HEAD method requested", "fileSize", len(file))
 	}

--- a/ihttp/ihttp_test.go
+++ b/ihttp/ihttp_test.go
@@ -149,14 +149,6 @@ func TestHandle(t *testing.T) {
 				StatusCode: http.StatusNotFound,
 			},
 		},
-		{
-			name: "write failure",
-			req:  req{method: "GET", url: "/snp.efi"},
-			want: &http.Response{
-				StatusCode: http.StatusInternalServerError,
-			},
-			failWrite: true,
-		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

This PR switches the HTTP server implementation to use http.ServeContent, which means that it now has support for more features like sending MIME types and handling range requests.

## Why is this needed

In certain cases, BMCs try to make HTTP range requests to avoid accessing downloading the entire boot media at once. With this change, those attempts no longer fail.

## How Has This Been Tested?

Booted a Dell R640 with a virtual media image hosted on ipxedust.

## How are existing users impacted? What migration steps/scripts do we need?

Should be no impact. HTTP server just supports more features.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
