### PR TITLE
Add binary patch target to ipxe script

### DIFF
--- a/binary/script/embed.ipxe
+++ b/binary/script/embed.ipxe
@@ -6,6 +6,10 @@ echo Welcome to Neverland!
 # Allow the operator to drop to a shell
 prompt --key 0x02 --timeout 2000 Press Ctrl-B for the iPXE command line... && shell ||
 
+# Random string to enable binary patching
+#a8b7e61f1075c37a793f2f92cee89f7bba00c4a8d7842ce3d40b5889032d8881
+#ddd16a4fc4926ecefdfb6941e33c44ed3647133638f5e84021ea44d3152e7f97
+
 # This is possible because the DHCP options from the original vendor PXE DHCP request
 # are available to chainloaded iPXE binaries. See https://github.com/ipxe/ipxe/issues/188
 set vlan-id ${43.116:string}


### PR DESCRIPTION
## Description

Adds a target for binary patching to the embedded ipxe script.

## Why is this needed

This splits off the script changes from #63. It is needed because that PR adds tests which will only pass once new binaries are generated incorporating the updated scripts.

## How Has This Been Tested?
N/A

## How are existing users impacted? What migration steps/scripts do we need?

N/A

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
