### PR TITLE
Build ipxe.iso binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ help: ## show this help message
 include lint.mk
 
 .PHONY: binary
-binary: binary/ipxe.efi binary/snp.efi binary/undionly.kpxe ## build all upstream ipxe binaries
+binary: binary/ipxe.efi binary/snp.efi binary/undionly.kpxe binary/ipxe.iso ## build all upstream ipxe binaries
 
 # ipxe_sha_or_tag := v1.21.1 # could not get this tag to build ipxe.efi
 # https://github.com/ipxe/ipxe/tree/2265a65191d76ce367913a61c97752ab88ab1a59
@@ -35,9 +35,12 @@ binary/undionly.kpxe: $(ipxe_readme) ## build undionly.kpxe
 binary/snp.efi: $(ipxe_readme) ## build snp.efi
 	+${IPXE_BUILD_SCRIPT} bin-arm64-efi/snp.efi "$(ipxe_sha_or_tag)" $(ipxe_build_in_docker) $@  "${IPXE_NIX_SHELL}" "CROSS_COMPILE=aarch64-unknown-linux-gnu-"
 
+binary/ipxe.iso: $(ipxe_readme) ## build ipxe.iso
+	+${IPXE_BUILD_SCRIPT} bin-x86_64-efi/ipxe.iso "$(ipxe_sha_or_tag)" $(ipxe_build_in_docker) $@  "${IPXE_NIX_SHELL}"
+
 .PHONY: binary/clean
 binary/clean: ## clean ipxe binaries, upstream ipxe source code directory, and ipxe source tarball
-	rm -rf binary/ipxe.efi binary/snp.efi binary/undionly.kpxe
+	rm -rf binary/ipxe.efi binary/snp.efi binary/undionly.kpxe binary/ipxe.iso
 	rm -rf upstream-*
 	rm -rf ipxe-*
 

--- a/binary/script/build_and_pr.sh
+++ b/binary/script/build_and_pr.sh
@@ -4,6 +4,8 @@ set -uxo pipefail
 
 # tracked_files defines the files that will cause the iPXE binaries to be rebuilt.
 tracked_files=(
+    "./script/build_ipxe.sh"
+    "./script/build_and_pr.sh"
     "./script/ipxe-customizations/console.h"
     "./script/ipxe-customizations/isa.h"
     "./script/ipxe-customizations/colour.h"
@@ -16,6 +18,7 @@ tracked_files=(
     "./ipxe.efi"
     "./snp.efi"
     "./undionly.kpxe"
+    "./ipxe.iso"
 )
 
 # binaries defines the files that will be built if any tracked_files changes are detected.
@@ -24,6 +27,7 @@ binaries=(
     "snp.efi"
     "ipxe.efi"
     "undionly.kpxe"
+    "ipxe.iso"
 )
 
 git_email="github-actions[bot]@users.noreply.github.com"
@@ -112,7 +116,7 @@ function create_branch() {
 # shellcheck disable=SC2086
 # commit changes to git
 function commit_changes() {
-    local files="${1:-script/sha512sum.txt snp.efi ipxe.efi undionly.kpxe}"
+    local files="${1:-script/sha512sum.txt snp.efi ipxe.efi undionly.kpxe ipxe.iso}"
     local message="${2:-Updated iPXE}"
 
     # commit changes

--- a/binary/script/build_ipxe.sh
+++ b/binary/script/build_ipxe.sh
@@ -70,6 +70,10 @@ function copy_custom_files() {
     bin-arm64-efi/snp.efi)
     	cp binary/script/ipxe-customizations/general.efi.h "${ipxe_dir}"/src/config/local/general.h
     	;;
+    bin-x86_64-efi/ipxe.iso)
+    	cp binary/script/ipxe-customizations/general.efi.h "${ipxe_dir}"/src/config/local/general.h
+    	cp binary/script/ipxe-customizations/isa.h "${ipxe_dir}"/src/config/local/isa.h
+    	;;
     *) echo "unknown binary: ${ipxe_bin}" >&2 && exit 1 ;;
     esac
 }


### PR DESCRIPTION
## Description

Updates the build scripts to also produce an amd64 ipxe.iso binary. Once the CI has generated the binary, I'll make a follow-up PR to expose it from the ipxedust server.

## Why is this needed

An ISO file is another useful file format for booting servers. In particular, it is required to boot using a virtual cdrom drive.

## How Has This Been Tested?

Used the scripts to build an ISO and then booted a Dell server using it.

## How are existing users impacted? What migration steps/scripts do we need?

Adds about 2 MB to ipxedust.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
