### PR TITLE
Add xorriso dependency for ipxe.iso build:

### DIFF
--- a/binary/script/shell.nix
+++ b/binary/script/shell.nix
@@ -24,6 +24,7 @@ in
             gnused
             go
             perl
+            xorriso
             xz
           ]
           ++ lib.optionals stdenv.isLinux [


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
The build will fail without this. `util/genfsimg: could not find isolinux.bin`

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
