### PR TITLE
Patch iPXE src to find isolinux.bin in the nix env:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ BINARY := ipxe
 IPXE_BUILD_SCRIPT := binary/script/build_ipxe.sh
 IPXE_FETCH_SCRIPT := binary/script/fetch_and_extract_ipxe.sh
 IPXE_NIX_SHELL := binary/script/shell.nix
+IPXE_ISO_BUILD_PATCH := binary/script/iso.patch
 
 help: ## show this help message
 	@grep -E '^[a-zA-Z_-]+.*:.*?## .*$$' Makefile | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[32m%-30s\033[0m %s\n", $$1, $$2}'
@@ -23,7 +24,7 @@ ipxe_build_in_docker := $(shell if [ $(OSFLAG) = "darwin" ]; then echo true; els
 .PHONY: extract-ipxe
 extract-ipxe: $(ipxe_readme) ## Fetch and extract ipxe source
 $(ipxe_readme): binary/script/ipxe.commit
-	${IPXE_FETCH_SCRIPT} "$(ipxe_sha_or_tag)"
+	${IPXE_FETCH_SCRIPT} "$(ipxe_sha_or_tag)" ${IPXE_ISO_BUILD_PATCH}
 	touch "$@"
 
 binary/ipxe.efi: $(ipxe_readme) ## build ipxe.efi

--- a/binary/script/fetch_and_extract_ipxe.sh
+++ b/binary/script/fetch_and_extract_ipxe.sh
@@ -30,7 +30,18 @@ function extract_ipxe_repo() {
 	fi
 }
 
+# patch_ipxe is needed to apply any patches needed to aid the build process.
+# currently the only use case if for ipxe.iso building.
+function patch_ipxe() {
+	local archive_dir="$1"
+	local patch_file="$2"
+
+	echo "applying patch"
+	patch --verbose -s -p1 -t -d "${archive_dir}" < "${patch_file}"
+}
+
 ipxe_sha_or_tag=$1
 archive_name=ipxe-${ipxe_sha_or_tag}.tar.gz
 download_ipxe_repo "${ipxe_sha_or_tag}" "${archive_name}"
 extract_ipxe_repo "${archive_name}" "upstream-${ipxe_sha_or_tag}"
+patch_ipxe "upstream-${ipxe_sha_or_tag}" "$2"

--- a/binary/script/iso.patch
+++ b/binary/script/iso.patch
@@ -1,0 +1,25 @@
+From 302c5dc6f92d4e8502e47672f89494deb332cb7b Mon Sep 17 00:00:00 2001
+From: Jacob Weinstock <jakobweinstock@gmail.com>
+Date: Sun, 5 Mar 2023 09:24:47 -0700
+Subject: [PATCH] Add nix location for isolinux.bin
+
+Signed-off-by: Jacob Weinstock <jakobweinstock@gmail.com>
+---
+ src/util/genfsimg | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/util/genfsimg b/src/util/genfsimg
+index 0c069279..a40fd520 100755
+--- a/src/util/genfsimg
++++ b/src/util/genfsimg
+@@ -107,6 +107,7 @@ copy_syslinux_file() {
+ 	/usr/local/share/syslinux/bios/com32/elflink/ldlinux \
+ 	/usr/local/share/syslinux/modules/bios \
+ 	/usr/lib/ISOLINUX \
++	$(echo $buildInputs | tr ' ' '\n' | grep syslinux)/share/syslinux \
+ 	; do
+ 	if [ -e "${SRCDIR}/${FILENAME}" ] ; then
+ 	    install -m 644 "${SRCDIR}/${FILENAME}" "${DESTDIR}/"
+-- 
+2.34.1
+

--- a/binary/script/shell.nix
+++ b/binary/script/shell.nix
@@ -24,6 +24,7 @@ in
             gnused
             go
             perl
+            syslinux
             xorriso
             xz
           ]


### PR DESCRIPTION
## Description
<!--- Please describe what this PR is going to change -->
The iPXE src build scripts for building `ipxe.iso` are hardcoded to look for the `isolinux.bin` in `/usr/lib/ISOLINUX`. This fixes the fixes iPXE iso build to work with our nix setup.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
