### PR TITLE
Add missing dependency for building ipxe.iso

### DIFF
--- a/binary/script/shell.nix
+++ b/binary/script/shell.nix
@@ -23,6 +23,7 @@ in
             gnumake
             gnused
             go
+            mtools
             perl
             syslinux
             xorriso


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Fix the failing build for `ipxe.iso`.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
