### PR TITLE
Autoboot from the interface that has obtained an IP address through DHCP

### DIFF
--- a/binary/script/embed.ipxe
+++ b/binary/script/embed.ipxe
@@ -15,6 +15,15 @@ prompt --key 0x02 --timeout 2000 Press Ctrl-B for the iPXE command line... && sh
 set vlan-id ${43.116:string}
 isset ${vlan-id} && goto boot-with-vlan ||
 
+:iterate-interfaces
+set idx:int32 0
+:interfaces-loop
+isset ${net${idx}/ip} && goto interfaces-loop-done || iseq ${idx} 50 && goto autoboot || inc idx && goto interfaces-loop
+
+:interfaces-loop-done
+echo Booting from net${idx}...
+autoboot net${idx}
+
 :autoboot
 autoboot
 


### PR DESCRIPTION
Modify the ipxe script to identify and autoboot from the interface that has successfully obtained an IP address through DHCP. Implementing this solution will result in a faster boot process and improved overall efficiency.

Fixes: #83

## Description

<!--- Please describe what this PR is going to change -->

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #83

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
