### PR TITLE
Build EFI bootable floppy ipxe.img

### DIFF
--- a/binary/script/build_and_pr.sh
+++ b/binary/script/build_and_pr.sh
@@ -19,6 +19,7 @@ tracked_files=(
     "./snp.efi"
     "./undionly.kpxe"
     "./ipxe.iso"
+    "./ipxe-efi.img"
 )
 
 # binaries defines the files that will be built if any tracked_files changes are detected.
@@ -28,6 +29,7 @@ binaries=(
     "ipxe.efi"
     "undionly.kpxe"
     "ipxe.iso"
+    "ipxe-efi.img"
 )
 
 git_email="github-actions[bot]@users.noreply.github.com"

--- a/binary/script/shell.nix
+++ b/binary/script/shell.nix
@@ -6,9 +6,9 @@ in
       import (_pkgs.fetchFromGitHub {
         owner = "NixOS";
         repo = "nixpkgs";
-        #branch@date: nixos-21.11@2022-08-02
-        rev = "eabc38219184cc3e04a974fe31857d8e0eac098d";
-        sha256 = "04ffwp2gzq0hhz7siskw6qh9ys8ragp7285vi1zh8xjksxn1msc5";
+        #branch@date: release-23.05@2023-09-11
+        rev = "4610292e25a414c2b111a7d99075cf1683e5a359";
+        hash = "sha256-ddMK+MKncPuPgMzsR72ndx4VObAjnM+R73+F6wL0aPs=";
       }) {},
   }:
     with pkgs; let
@@ -17,19 +17,21 @@ in
         buildInputs =
           [
             curl
+            dosfstools
             expect
-            gcc9
+            gcc12
             git
             gnumake
             gnused
             go
             mtools
             perl
+            qemu-utils
             syslinux
             xorriso
             xz
           ]
           ++ lib.optionals stdenv.isLinux [
-            pkgsCross.aarch64-multiplatform.buildPackages.gcc9
+            pkgsCross.aarch64-multiplatform.buildPackages.gcc12
           ];
       }

--- a/docs/DifficultHardware.md
+++ b/docs/DifficultHardware.md
@@ -1,0 +1,39 @@
+# Difficult Hardware
+
+Most modern hardware is capable of PXE booting just fine.
+Sometimes strange combinations of different NIC hardware / firmware connected
+to specific switches can misbehave.
+
+In those situations you might want to boot into a build of iPXE but completely
+sidestep the PXE stack in your NIC firmware.
+
+We already ship ipxe.iso that can be used in many situations, but most of the
+time that requires either an active connection from a virtual KVM client
+or network access from the BMC to a storage target hosting the ISO.
+
+Some BMCs support uploading a floppy image into BMC memory and booting from that.
+To support that use case we have started packaging our EFI build into a bootable
+floppy image that can be used for this purpose.
+
+For other projects or use cases that wish to replicate this functionality, with
+the appropriate versions of qemu-img, dosfstools and mtools you can build something
+similar yourself from upstream iPXE like so:
+
+```
+# create a 1440K raw disk image
+qemu-img create -f raw ipxe-efi.img 1440K
+# format it with an MBR and a FAT12 filesystem
+mkfs.vfat --mbr=y -F 12 -n IPXE ipxe-efi.img
+
+# Create the EFI expected directory structure
+mmd -i ipxe-efi.img ::/EFI
+mmd -i ipxe-efi.img ::/EFI/BOOT
+
+# Copy ipxe.efi as the default x86_64 efi boot file
+curl -LO https://boot.ipxe.org/ipxe.efi
+mcopy -i ipxe-efi.img ipxe.efi ::/EFI/BOOT/BOOTX64.efi
+```
+
+As of writing other projects are working on automating the upload
+of this floppy to a BMC.
+See draft PR https://github.com/bmc-toolbox/bmclib/pull/347


### PR DESCRIPTION
## Description

This PR adds code to build and ship a bootable floppy image (EFI only) that can boot straight into our EFI build of iPXE.

## Why is this needed

Operators dealing with finicky hardware may want to use this as described in `docs/DifficultHardware.md`

## How Has This Been Tested?

The resulting floppy image has been tested on some physical servers.

## How are existing users impacted? What migration steps/scripts do we need?

N/A

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
