### PR TITLE
iPXE build scripts update

### DIFF
--- a/binary/binary.go
+++ b/binary/binary.go
@@ -9,18 +9,22 @@ import (
 )
 
 // IpxeEFI is the UEFI iPXE binary for x86 architectures.
+//
 //go:embed ipxe.efi
 var IpxeEFI []byte
 
 // Undionly is the BIOS iPXE binary for x86 architectures.
+//
 //go:embed undionly.kpxe
 var Undionly []byte
 
 // SNP is the UEFI iPXE binary for ARM architectures.
+//
 //go:embed snp.efi
 var SNP []byte
 
 // IpxeISO is the iPXE ISO image.
+//
 //go:embed ipxe.iso
 var IpxeISO []byte
 

--- a/binary/binary_test.go
+++ b/binary/binary_test.go
@@ -30,9 +30,9 @@ func TestPatch(t *testing.T) {
 	}{
 		{
 			name:    "no patch",
-			content: []byte("foo\n"+string(magicString)),
+			content: []byte("foo\n" + string(magicString)),
 			patch:   []byte(""),
-			want:    []byte("foo\n"+string(magicString)),
+			want:    []byte("foo\n" + string(magicString)),
 		},
 		{
 			name:    "nil patch",
@@ -48,15 +48,15 @@ func TestPatch(t *testing.T) {
 		},
 		{
 			name:    "patch too long",
-			content: []byte("foo\n"+string(magicString)),
+			content: []byte("foo\n" + string(magicString)),
 			patch:   make([]byte, 1024),
 			wantErr: true,
 		},
 		{
 			name:    "patch",
-			content: []byte("foo\n"+string(magicString)),
+			content: []byte("foo\n" + string(magicString)),
 			patch:   []byte("baz"),
-			want:    []byte("foo\nbaz"+string(magicStringPadding[3:])),
+			want:    []byte("foo\nbaz" + string(magicStringPadding[3:])),
 		},
 	}
 	for _, tt := range tests {

--- a/binary/script/build_and_pr.sh
+++ b/binary/script/build_and_pr.sh
@@ -69,7 +69,8 @@ function clean_iPXE() {
 function build_iPXE() {
     # build iPXE
     echo "Building iPXE"
-    if ! (cd "$(git rev-parse --show-toplevel)"; nix-shell "$(dirname "$0")/shell.nix" --run 'make binary'); then
+    top_level_dir="$(git rev-parse --show-toplevel)"
+    if ! (cd "${top_level_dir}"; nix-shell "${top_level_dir}/binary/script/shell.nix" --run 'make binary'); then
         echo "Failed to build iPXE" 1>&2
         exit 1
     fi

--- a/binary/script/build_and_pr.sh
+++ b/binary/script/build_and_pr.sh
@@ -69,7 +69,7 @@ function clean_iPXE() {
 function build_iPXE() {
     # build iPXE
     echo "Building iPXE"
-    if ! (cd "$(git rev-parse --show-toplevel)"; make binary); then
+    if ! (cd "$(git rev-parse --show-toplevel)"; nix-shell $(dirname "$0")/shell.nix --run 'make binary'); then
         echo "Failed to build iPXE" 1>&2
         exit 1
     fi

--- a/binary/script/build_and_pr.sh
+++ b/binary/script/build_and_pr.sh
@@ -69,7 +69,7 @@ function clean_iPXE() {
 function build_iPXE() {
     # build iPXE
     echo "Building iPXE"
-    if ! (cd "$(git rev-parse --show-toplevel)"; nix-shell $(dirname "$0")/shell.nix --run 'make binary'); then
+    if ! (cd "$(git rev-parse --show-toplevel)"; nix-shell "$(dirname "$0")/shell.nix" --run 'make binary'); then
         echo "Failed to build iPXE" 1>&2
         exit 1
     fi

--- a/example/main.go
+++ b/example/main.go
@@ -55,7 +55,7 @@ func listenAndServe(ctx context.Context, logger logr.Logger) error {
 }
 
 func serve(ctx context.Context, logger logr.Logger) error {
-	conn, err := net.Listen("tcp", "0.0.0.0:0") // nolint: gosec // this is just example code
+	conn, err := net.Listen("tcp", "0.0.0.0:0") //nolint: gosec // this is just example code
 	if err != nil {
 		return err
 	}

--- a/ihttp/ihttp_test.go
+++ b/ihttp/ihttp_test.go
@@ -100,7 +100,7 @@ func TestListenAndServeHTTP(t *testing.T) {
 }
 
 func TestHandle(t *testing.T) {
-	patched_binary, _ := binary.Patch(binary.Files["snp.efi"], []byte("echo 'hello world'"))
+	patched, _ := binary.Patch(binary.Files["snp.efi"], []byte("echo 'hello world'"))
 
 	type req struct {
 		method string
@@ -154,16 +154,16 @@ func TestHandle(t *testing.T) {
 		},
 		{
 			name: "patch",
-			req: req{method: "GET", url: "/30:23:03:73:a5:a7/snp.efi-00-23b1e307bb35484f535a1f772c06910e-d887dc3912240434-01"},
+			req:  req{method: "GET", url: "/30:23:03:73:a5:a7/snp.efi-00-23b1e307bb35484f535a1f772c06910e-d887dc3912240434-01"},
 			want: &http.Response{
 				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(bytes.NewBuffer(patched_binary)),
+				Body:       ioutil.NopCloser(bytes.NewBuffer(patched)),
 			},
 			patch: []byte("echo 'hello world'"),
 		},
 		{
 			name: "bad patch",
-			req: req{method: "GET", url: "/30:23:03:73:a5:a7/snp.efi-00-23b1e307bb35484f535a1f772c06910e-d887dc3912240434-01"},
+			req:  req{method: "GET", url: "/30:23:03:73:a5:a7/snp.efi-00-23b1e307bb35484f535a1f772c06910e-d887dc3912240434-01"},
 			want: &http.Response{
 				StatusCode: http.StatusInternalServerError,
 			},

--- a/itftp/itftp.go
+++ b/itftp/itftp.go
@@ -24,7 +24,7 @@ import (
 
 // Handler is the struct that implements the TFTP read and write function handlers.
 type Handler struct {
-	Log logr.Logger
+	Log   logr.Logger
 	Patch []byte
 }
 

--- a/lint.mk
+++ b/lint.mk
@@ -37,7 +37,7 @@ shellcheck-fix: $(SHELLCHECK_BIN)
 	$(SHELLCHECK_BIN) $(shell find . -name "*.sh") -f diff | { read -t 1 line || exit 0; { echo "$$line" && cat; } | git apply -p2; }
 
 GOLANGCI_LINT_CONFIG := $(LINT_ROOT)/.golangci.yml
-GOLANGCI_LINT_VERSION ?= v1.43.0
+GOLANGCI_LINT_VERSION ?= v1.54.2
 GOLANGCI_LINT_BIN := out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH)
 $(GOLANGCI_LINT_BIN):
 	mkdir -p out/linters


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Update iPXE build scripts. Instead of having the `build_ipxe.sh` handle running in docker or locally with nix, we remove all that out so that it is up to the user of `build_ipxe.sh` to get into a nix-shell using `binary/script/shell.nix`. The script no longer calls docker or nix to run the iPXE build. The purpose of this is to simplify the build process, adding features, maintainability, etc. This will also fix the build issue on main.

Also updated the `golangci-lint` to the latest version and resolve lint issues.


## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
