### PR TITLE
Floppy build fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,14 +40,8 @@ binary/snp.efi: $(ipxe_readme) ## build snp.efi
 binary/ipxe.iso: $(ipxe_readme) ## build ipxe.iso
 	+${IPXE_BUILD_SCRIPT} bin-x86_64-efi/ipxe.iso "$(ipxe_sha_or_tag)" $(ipxe_build_in_docker) $@  "${IPXE_NIX_SHELL}"
 
-.DELETE_ON_ERROR: binary/ipxe-efi.img
-binary/ipxe-efi.img: binary/ipxe.efi
-	qemu-img create -f raw $@ 1440K
-	sgdisk --clear --set-alignment=34 --new 1:34:-0 --typecode=1:EF00 --change-name=1:"IPXE" $@
-	mkfs.vfat -F 12 -n "IPXE" --offset 34 $@ 1400
-	mmd -i $@@@17K ::/EFI
-	mmd -i $@@@17K ::/EFI/BOOT
-	mcopy -i $@@@17K $< ::/EFI/BOOT/BOOTX64.efi
+binary/ipxe-efi.img: binary/ipxe.efi ## build ipxe-efi.img
+	binary/script/build_floppy.sh $(ipxe_build_in_docker) "${IPXE_NIX_SHELL}" "$@"
 
 .PHONY: binary/clean
 binary/clean: ## clean ipxe binaries, upstream ipxe source code directory, and ipxe source tarball

--- a/Makefile
+++ b/Makefile
@@ -40,13 +40,14 @@ binary/snp.efi: $(ipxe_readme) ## build snp.efi
 binary/ipxe.iso: $(ipxe_readme) ## build ipxe.iso
 	+${IPXE_BUILD_SCRIPT} bin-x86_64-efi/ipxe.iso "$(ipxe_sha_or_tag)" $(ipxe_build_in_docker) $@  "${IPXE_NIX_SHELL}"
 
+.DELETE_ON_ERROR: binary/ipxe-efi.img
 binary/ipxe-efi.img: binary/ipxe.efi
-	qemu-img create -f raw $@.t 1440K
-	mkfs.vfat --mbr=y -F 12 -n IPXE $@.t
-	mmd -i $@.t ::/EFI
-	mmd -i $@.t ::/EFI/BOOT
-	mcopy -i $@.t $< ::/EFI/BOOT/BOOTX64.efi
-	mv $@.t $@
+	qemu-img create -f raw $@ 1440K
+	sgdisk --clear --set-alignment=34 --new 1:34:-0 --typecode=1:EF00 --change-name=1:"IPXE" $@
+	mkfs.vfat -F 12 -n "IPXE" --offset 34 $@ 1400
+	mmd -i $@@@17K ::/EFI
+	mmd -i $@@@17K ::/EFI/BOOT
+	mcopy -i $@@@17K $< ::/EFI/BOOT/BOOTX64.efi
 
 .PHONY: binary/clean
 binary/clean: ## clean ipxe binaries, upstream ipxe source code directory, and ipxe source tarball

--- a/binary/script/build_floppy.sh
+++ b/binary/script/build_floppy.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -eux
+
+
+function dockerize() {
+            docker run -it --rm -v "${PWD}":/code -w /code nixos/nix "$@"
+}
+
+function hasType() {
+    if [ -z "$(type type)" ]; then
+        echo "type command not found"
+        return 1
+    fi
+}
+
+function hasDocker() {
+    if [ -z "$(type docker)" ]; then
+        echo "docker command not found"
+        return 1
+    fi
+}
+
+function hasNixShell() {
+    if [ -z "$(type nix-shell)" ]; then
+        echo "nix-shell command not found"
+        return 1
+    fi
+}
+
+function hasUname() {
+    if [ -z "$(type uname)" ]; then
+        echo "uname command not found"
+        return 1
+    fi
+}
+
+# build_floppy will build the boot floppy image
+function main() {
+    local run_in_docker="$1"
+    local nix_shell="$2"
+
+    # check for prerequisites
+    hasType
+    hasNixShell
+    hasUname
+    local OS_TEST
+    OS_TEST=$(uname | tr '[:upper:]' '[:lower:]')
+    if [[ "${OS_TEST}" != *"linux"* ]]; then
+        hasDocker
+    fi
+
+    if [ "${run_in_docker}" = true ]; then
+            echo "running in docker"
+            dockerize "$0" false "$2" "$3"
+    else
+        echo "running locally"
+        nix-shell "${nix_shell}" --run "make -f floppy.mk $3"
+    fi
+}
+
+main "$@"

--- a/binary/script/shell.nix
+++ b/binary/script/shell.nix
@@ -24,6 +24,7 @@ in
             gnumake
             gnused
             go
+            gptfdisk
             mtools
             perl
             qemu-utils

--- a/floppy.mk
+++ b/floppy.mk
@@ -1,0 +1,8 @@
+.DELETE_ON_ERROR: binary/ipxe-efi.img
+binary/ipxe-efi.img: binary/ipxe.efi ## build ipxe-efi.img
+	qemu-img create -f raw $@ 1440K
+	sgdisk --clear --set-alignment=34 --new 1:34:-0 --typecode=1:EF00 --change-name=1:"IPXE" $@
+	mkfs.vfat -F 12 -n "IPXE" --offset 34 $@ 1400
+	mmd -i $@@@17K ::/EFI
+	mmd -i $@@@17K ::/EFI/BOOT
+	mcopy -i $@@@17K $< ::/EFI/BOOT/BOOTX64.efi


### PR DESCRIPTION
## Description

This fixes the build for the floppy image to properly use Nix and docker.

## Why is this needed

The build is currently broken and it's all my fault.

## How Has This Been Tested?
Tested on both a NixOS Linux machine and an x86 Mac.