### PR TITLE
floppy: switch to gpt partitioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,13 +41,14 @@ binary/snp.efi: $(ipxe_readme) ## build snp.efi
 binary/ipxe.iso: $(ipxe_readme) ## build ipxe.iso
 	+${IPXE_BUILD_SCRIPT} bin-x86_64-efi/ipxe.iso "$(ipxe_sha_or_tag)" $@
 
+.DELETE_ON_ERROR: binary/ipxe-efi.img
 binary/ipxe-efi.img: binary/ipxe.efi ## build ipxe-efi.img
-	qemu-img create -f raw $@.t 1440K
-	mkfs.vfat --mbr=y -F 12 -n IPXE $@.t
-	mmd -i $@.t ::/EFI
-	mmd -i $@.t ::/EFI/BOOT
-	mcopy -i $@.t $< ::/EFI/BOOT/BOOTX64.efi
-	mv $@.t $@
+	qemu-img create -f raw $@ 1440K
+	sgdisk --clear --set-alignment=34 --new 1:34:-0 --typecode=1:EF00 --change-name=1:"IPXE" $@
+	mkfs.vfat -F 12 -n "IPXE" --offset 34 $@ 1400
+	mmd -i $@@@17K ::/EFI
+	mmd -i $@@@17K ::/EFI/BOOT
+	mcopy -i $@@@17K $< ::/EFI/BOOT/BOOTX64.efi
 
 .PHONY: binary/clean
 binary/clean: ## clean ipxe binaries, upstream ipxe source code directory, and ipxe source tarball

--- a/binary/script/shell.nix
+++ b/binary/script/shell.nix
@@ -24,6 +24,7 @@ in
             gnumake
             gnused
             go
+            gptfdisk
             mtools
             perl
             qemu-utils


### PR DESCRIPTION
## Description

Switch the boot floppy to use GPT partitioning

## Why is this needed

The GPT partition table allows us to label the partition more clearly
which makes it easier for other tooling to detect / ignore it.

## How Has This Been Tested?

Mostly just on my NixOS machine, though also under docker in #90 which is no longer needed thanks to #89

## How are existing users impacted? What migration steps/scripts do we need?

N/A