### PR TITLE
ipxedust: add nap.h to arm64 build to set NAP_NULL to support u-boot

### DIFF
--- a/binary/script/build_and_pr.sh
+++ b/binary/script/build_and_pr.sh
@@ -13,6 +13,7 @@ tracked_files=(
     "./script/ipxe-customizations/general.efi.h"
     "./script/ipxe-customizations/general.undionly.h"
     "./script/ipxe-customizations/common.h"
+    "./script/ipxe-customizations/nap.h"
     "./script/embed.ipxe"
     "./script/ipxe.commit"
     "./ipxe.efi"

--- a/binary/script/build_ipxe.sh
+++ b/binary/script/build_ipxe.sh
@@ -63,6 +63,7 @@ function copy_custom_files() {
     	;;
     bin-arm64-efi/snp.efi)
     	cp binary/script/ipxe-customizations/general.efi.h "${ipxe_dir}"/src/config/local/general.h
+    	cp binary/script/ipxe-customizations/nap.h "${ipxe_dir}"/src/config/local/nap.h
     	;;
     bin-x86_64-efi/ipxe.iso)
     	cp binary/script/ipxe-customizations/general.efi.h "${ipxe_dir}"/src/config/local/general.h

--- a/binary/script/ipxe-customizations/nap.h
+++ b/binary/script/ipxe-customizations/nap.h
@@ -1,0 +1,2 @@
+#undef NAP_EFIARM
+#define NAP_NULL


### PR DESCRIPTION
#### ipxedust: add nap.h to arm64 build to set NAP_NULL to support u-boot

- see https://github.com/ipxe/ipxe/discussions/605#discussioncomment-2273515
- "This will cause iPXE to leave the CPU spinning instead of putting it to sleep, and will avoid the problems on U-Boot."
- Seems harmless on non U-Boot machines -- the CPU will spin during the key timeout (2s?) but that's about it.

