### PR TITLE
Add dhcp retries to embedded iPXE script:

### DIFF
--- a/binary/script/embed.ipxe
+++ b/binary/script/embed.ipxe
@@ -22,10 +22,22 @@ isset ${net${idx}/ip} && goto interfaces-loop-done || iseq ${idx} 50 && goto aut
 
 :interfaces-loop-done
 echo Booting from net${idx}...
-autoboot net${idx}
+set retry-max:int32 10
+set count:int32 1
+:retry-loop1
+echo trying dhcp ( attempt ${count}/${retry-max} )
+dhcp net${idx} && goto done1 || iseq ${count} ${retry-max} || inc count && goto retry-loop1
+:done1
+autoboot net${idx} || exit
 
 :autoboot
-autoboot
+set retry-max:int32 10
+set count:int32 1
+:retry-loop2
+echo trying dhcp ( attempt ${count}/${retry-max} )
+dhcp && goto done2 || iseq ${count} ${retry-max} || inc count && goto retry-loop2
+:done2
+autoboot || exit
 
 :boot-with-vlan
 set idx:int32 0


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This resolves issues when an interface might need some time before the upstream port is forwarding properly or if the firmware is slow, etc. I found this to make a Raspberry PI 4b boot consistently. This was also tested and resolved consistency issues with Cisco ACI switches using LACP configured interfaces.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
