### PR TITLE
Reduce number of receive buffers to resolve download hangs on Broadcom NetXtreme NICs

### DIFF
--- a/binary/script/build_ipxe.sh
+++ b/binary/script/build_ipxe.sh
@@ -86,7 +86,7 @@ function customize_aarch_build() {
 # https://github.com/ipxe/ipxe/issues/1023#issuecomment-1898585257
 function patch_bnxt_rx_buffers() {
     local ipxe_dir="$1"
-    sed -i.bak 's/\(#define NUM_RX_BUFFERS \).*/\12/' "${ipxe_dir}"/src/drivers/net/bnxt/bnxt.h
+    sed -i 's/\(#define NUM_RX_BUFFERS \).*/\12/' "${ipxe_dir}"/src/drivers/net/bnxt/bnxt.h
 }
 
 # customize orchestrates the process for adding custom headers to an ipxe compile.

--- a/binary/script/build_ipxe.sh
+++ b/binary/script/build_ipxe.sh
@@ -81,6 +81,14 @@ function customize_aarch_build() {
     sed -i.bak '/^WORKAROUND_CFLAGS/ s|^|#|' "${ipxe_dir}"/src/arch/arm64/Makefile
 }
 
+# Workaround for Broadcom NetXtreme driver bug that causes a hang when
+# trying to download large files. See this iPXE issue for more detail:
+# https://github.com/ipxe/ipxe/issues/1023#issuecomment-1898585257
+function patch_bnxt_rx_buffers() {
+    local ipxe_dir="$1"
+    sed -i.bak 's/\(#define NUM_RX_BUFFERS \).*/\12/' "${ipxe_dir}"/src/drivers/net/bnxt/bnxt.h
+}
+
 # customize orchestrates the process for adding custom headers to an ipxe compile.
 function customize() {
     local ipxe_dir="$1"
@@ -90,6 +98,7 @@ function customize() {
     copy_common_files "${ipxe_dir}"
     copy_custom_files "${ipxe_dir}" "${ipxe_bin}"
     customize_aarch_build "${ipxe_dir}"
+    patch_bnxt_rx_buffers "${ipxe_dir}"
 }
 
 function hasType() {


### PR DESCRIPTION
## Description
This resolves an issue where large file downloads will hang on Broadcom NetXtreme NICs. This issue was caused by commit [`059c4dc`](https://github.com/ipxe/ipxe/commit/059c4dc688cea6d9398d63ca10f5c00e94ae2159) which changed how drivers are loaded by iPXE. [A fix](https://github.com/ipxe/ipxe/issues/1023#issuecomment-1898585257) was identified in [this issue](https://github.com/ipxe/ipxe/issues/1023) wherein the number of receive buffers (defined as `NUM_RX_BUFFERS` in `src/drivers/net/bnxt/bnxt.h`) is reduced from the default value of 8 to 2.

## Why is this needed
This is required to fix an issue where downloading large files (e.g. a kernel or initial RAM filesystem) will hang on Broadcom devices.

## How Has This Been Tested?
This change was tested by using the committed modifications, rebuilding the iPXE binaries[^1], and then rebuilding smee with the new iPXE images.

[^1]: Commands used to rebuild binaries.
<details><summary>Build Instructions</summary>
<p>
```bash
$ make binary/clean
$ make extract-ipxe
$ make binaries
# In smee repository
$ go mod edit -replace=github.com/tinkerbell/ipxedust /path/to/local/ipxedust
```
</p>
</details> 

These changes were tested by attempting to boot HookOS via Tinkerbell on servers with Broadcom BCM957504-N425G and BCM957504-P425G NICs.

## How are existing users impacted? What migration steps/scripts do we need?
Fixes a bug--no action required by end users.

## Checklist:
- ~~[ ] updated the documentation and/or roadmap (if required)~~ N/A.
- ~~[ ] added unit or e2e tests~~ No tests, only changes build script.
- ~~[ ] provided instructions on how to upgrade~~ No specific upgrade instructions.
